### PR TITLE
Add DB tests and app tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 python3-virtualenv
 flask.sqlite
 .DS_Store
+env

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -32,13 +32,13 @@ class TestTimelinePost(unittest.TestCase):
         # If we wanted, we could re-bind the models to their original
         # database here. But for tests this is probably not necessary.
 
-        def test_timeline_post(self):
-            # Create 2 timeline posts
-            first_post = TimelinePost.create(name='John Doe', email='john@example.com', content='Hello world, I\'m John!')
-            assert first_post.id == 1
-            second_post = TimelinePost.create(name='Jane Doe', email='jane@example.com', content='Hello world, I\'m Jane!')
-            assert second_post.id == 2
+    def test_timeline_post(self):
+        # Create 2 timeline posts
+        first_post = TimelinePost.create(name='John Doe', email='john@example.com', content='Hello world, I\'m John!')
+        assert first_post.id == 1
+        second_post = TimelinePost.create(name='Jane Doe', email='jane@example.com', content='Hello world, I\'m Jane!')
+        assert second_post.id == 2
 
-            # TODO: GET timeline posts and assert that they are correct
-            for i, post in enumerate(TimelinePost.select()):
-                assert post.id == i
+        # TODO: GET timeline posts and assert that they are correct
+        for i, post in enumerate(TimelinePost.select()):
+            assert post.id == i

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,12 +1,15 @@
 import unittest
 from peewee import *
-from app import TimelinePost
 
+import os
+os.environ['TESTING'] = 'true'
+
+from app import TimelinePost
 
 MODELS = [TimelinePost]
 
 # use an in-memory SQLite for tests.
-test_db = SqliteDatabase('file:memory?mode=memory&cache=shared', uri=True)
+test_db = SqliteDatabase(':memory:', uri=True)
 
 class TestTimelinePost(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
# Summary of Changes
* Set `TESTING` environment variable to `'true'` in `test_db.py` to prevent issues when running `from app import TimelinePost`
* Set `test_db` back to default in-memory database
* Fix indentation for `test_timeline_post()` so it runs correctly
* Add `env/` virtual environment directory to `.gitignore`